### PR TITLE
Added CheckBoxFormElement to formelements

### DIFF
--- a/src/main/java/de/milchreis/uibooster/model/formelements/CheckBoxFormElement.java
+++ b/src/main/java/de/milchreis/uibooster/model/formelements/CheckBoxFormElement.java
@@ -1,0 +1,50 @@
+public class CheckBoxFormElement extends FormElement {
+  private boolean ticked;
+  private final JCheckBox button;
+  
+  /**
+   * Button label is propably more important than the component label.
+   */
+  public CheckBoxFormElement(String buttonLabel) {
+    this("", buttonLabel);
+  }
+
+  public TickBox(String label, String buttonLabel) {
+    super(label);
+    ticked = false;
+    button = new JCheckBox(buttonLabel);
+    button.addActionListener(l -> {
+      toogleTick();
+    });
+  }
+
+  /**
+   * Not exactly clear on the inner workings of this function
+   */
+  @Override
+  public JComponent createComponent(FormElementChangeListener onChange) {
+    return button;
+  }
+
+  @Override
+  public void setEnabled(boolean enable) {
+    button.setEnabled(enable);
+  }
+
+  @Override
+  public Object getValue() {
+    return ticked;
+  }
+
+  /**
+   * Conscious choice to be strict about the value.
+   */
+  @Override
+  public void setValue(Object value) {
+    // no-op
+  }
+
+  private void toogleTick() {
+    ticked ^= true;
+  }
+}


### PR DESCRIPTION
Simple form element that encapsulates a `JCheckBox` in order to give a more intuitive approach to `boolean` form fields.